### PR TITLE
Fix run scripts with cross-env and npm-run-all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3719,6 +3719,58 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha1-hlJkspZ33AFbqEGJGJZd0jL8VM8=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -7942,6 +7994,12 @@
         }
       }
     },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "merge-deep": {
       "version": "3.0.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/merge-deep/-/merge-deep-3.0.3.tgz",
@@ -8430,6 +8488,23 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha1-BEdiAqFe4OLiFAgIYb/xKlHZj7o=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
       }
     },
     "npm-run-path": {
@@ -8929,6 +9004,12 @@
       "version": "2.2.3",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/picomatch/-/picomatch-2.2.3.tgz",
       "integrity": "sha1-RlVH81nMwgbTxI5Goby4m/fuYZ0="
+    },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha1-7wmsLMBTPfHzJQzPLE02aw0SEUo=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -11787,6 +11868,17 @@
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.1.2",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
+      "integrity": "sha1-aFjKTzXFJo69XoYV4TJ9VfWe4xE=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
       }
     },
     "string.prototype.trimend": {

--- a/package.json
+++ b/package.json
@@ -10,17 +10,19 @@
   },
   "devDependencies": {
     "cors": "^2.8.5",
-    "express": "^4.17.1"
+    "cross-env": "^7.0.3",
+    "express": "^4.17.1",
+    "npm-run-all": "^4.1.5"
   },
   "scripts": {
     "start": "npm run start:full",
-    "start:a": "npm run start:server:a & npm run start:client",
-    "start:b": "npm run start:server:b & npm run start:client",
-    "start:full": "npm run start:server & npm run start:client",
+    "start:a": "npm-run-all --parallel start:server:a start:client",
+    "start:b": "npm-run-all --parallel start:server:b start:client",
+    "start:full": "npm-run-all --parallel start:server start:client",
     "start:client": "react-scripts start",
     "start:server": "node src/server.js",
-    "start:server:a": "NETWORK=a npm run start:server",
-    "start:server:b": "NETWORK=b npm run start:server",
+    "start:server:a": "cross-env NETWORK=a npm run start:server",
+    "start:server:b": "cross-env NETWORK=b npm run start:server",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
The run scripts weren't windows-friendly. They should be now.